### PR TITLE
OINK-1353 | Exchange Rate in DOP not getting rendered

### DIFF
--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -149,9 +149,9 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     getCeloAPY();
     getUsdcAPY();
     final user = ref.read(userProvider);
-    if (user?.country == "MX") {
+    if (user?.country == "MX" && false) { // TEMPORARY DISABLE MXN
       sourceCurrency = "MXN";
-    } else if (user?.country == "DO") {
+    } else if (user?.country == "DO" && false) { // TEMPORARY DISABLE MXN
       sourceCurrency = "DOP";
     } else {
       sourceCurrency = sourceCurrencyCodes.first['name'];
@@ -348,18 +348,18 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                 ),
                               ],
                             ),
-                            // Padding(
-                            //   padding: const EdgeInsets.only(top: 16.0),
-                            //   child: Text(
-                            //     "*1 USDC = ${(sourceCurrency == "MXN" ? suarmiUSDCExchage : alcanciaUSDCExchange).toStringAsFixed(2)} $sourceCurrency",
-                            //     style: TextStyle(
-                            //       fontSize: 13,
-                            //       fontWeight: FontWeight.normal,
-                            //       color: Colors.grey[700],
-                            //       fontStyle: FontStyle.italic,
-                            //     ),
-                            //   ),
-                            // ),
+                            Padding(
+                              padding: const EdgeInsets.only(top: 16.0),
+                              child: Text(
+                                "*1 USDC = ${(sourceCurrency == "MXN" ? suarmiUSDCExchage : alcanciaUSDCExchange).toStringAsFixed(2)} $sourceCurrency",
+                                style: TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.normal,
+                                  color: Colors.grey[700],
+                                  fontStyle: FontStyle.italic,
+                                ),
+                              ),
+                            ),
                           ],
                         ),
                       ),


### PR DESCRIPTION
## Summary
Reactivated exchange rate in deposit card, I mistakenly commented out the code in a previous PR without realizing the actual error was the source currency being set to MXN in the screen's `initState`

## Requirements
N/A

## Type of change
- [ ] feature
- [x] hotfix
- [ ] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
N/A

## How has this been tested?
- [ ] Source currency automatically sets to DOP (the only available one), this can be checked by setting breakpoints inside the build method
- [ ] USDC<>DOP exchange rate appears below target currency field

## Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 08 28 52](https://github.com/Alcancia-io/Alcancia-FrontEnd/assets/39177932/0a767804-bfc7-4376-b72a-5fd43829633b)
## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?