### PR TITLE
OINK-1377 | Implement getCryptoWithdrawalFee

### DIFF
--- a/lib/src/screens/withdraw/withdraw_controller.dart
+++ b/lib/src/screens/withdraw/withdraw_controller.dart
@@ -73,4 +73,14 @@ class WithdrawController {
     final data = response.data?['executeCryptoWithdrawal'];
     return ExternalWithdrawal.fromJSON(data);
   }
+
+  Future<double> getCryptoWithdrawalFee() async {
+    final response = await _cryptoWalletService.getCryptoWithdrawalFee();
+    if (response.hasException) {
+      var exception = _exceptionHandler.handleException(response.exception);
+      throw Exception(exception);
+    }
+    final data = response.data?['getCryptoWithdrawalFee'];
+    return double.tryParse(data['fee'].toString()) ?? 1;
+  }
 }

--- a/lib/src/shared/graphql/queries/get_crypto_withdrawal_fee_query.dart
+++ b/lib/src/shared/graphql/queries/get_crypto_withdrawal_fee_query.dart
@@ -1,0 +1,7 @@
+const String getCryptoWithdrawalQuery = """
+    query {
+      getCryptoWithdrawalFee {
+        fee
+      }
+    }
+""";

--- a/lib/src/shared/services/crypto_wallet_service.dart
+++ b/lib/src/shared/services/crypto_wallet_service.dart
@@ -1,4 +1,5 @@
 import 'package:alcancia/src/shared/graphql/mutations/external_withdraw_query.dart';
+import 'package:alcancia/src/shared/graphql/queries/get_crypto_withdrawal_fee_query.dart';
 import 'package:alcancia/src/shared/services/graphql_service.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
@@ -23,6 +24,15 @@ class CryptoWalletService {
             "receiverAddress": address,
           }
         },
+      ),
+    );
+  }
+
+  Future<QueryResult> getCryptoWithdrawalFee() async {
+    final clientResponse = await client;
+    return await clientResponse.mutate(
+      MutationOptions(
+        document: gql(getCryptoWithdrawalQuery),
       ),
     );
   }


### PR DESCRIPTION
## Summary
Implements new `getCryptoWithdrawalFee`. This gets saved to the device's storage and expires after one day.

## Requirements
N/A

## Type of change
- [ ] feature
- [ ] hotfix
- [ ] fix
- [x] refactor
- [ ] chore
- [ ] docs

## How to test?
Go to crypto withdrawal screen. The fee should load at screen init.

## How has this been tested?


## Screenshots


## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?