### PR TITLE
feat/OINK-1413 | USD Withdrawal/Deposit Spreads from Remote Configs

### DIFF
--- a/lib/src/resources/l10n/app_en.arb
+++ b/lib/src/resources/l10n/app_en.arb
@@ -211,7 +211,7 @@
 	"labelBank": "Bank",
 	"labelAccountNumber": "Account number",
 	"labelCedula": "Cedula",
-	"labelAmountDOP": "Amount in DOP",
+	"labelAmount": "Amount in",
 	"errorCedulaLength": "The cedula must consist of 11 digits",
 	"errorEmailRequired": "Email is required",
 	"alertErrorForgotPasswordCode": "There was an error sending the code, please check your email and try again",

--- a/lib/src/resources/l10n/app_es.arb
+++ b/lib/src/resources/l10n/app_es.arb
@@ -293,7 +293,7 @@
 	"labelBank": "Banco",
 	"labelAccountNumber": "Número de cuenta",
 	"labelCedula": "Número de cédula",
-	"labelAmountDOP": "Monto en DOP",
+	"labelAmount": "Monto en",
 	"errorCedulaLength": "El número de cédula debe tener 11 dígitos",
 	"errorEmailRequired": "El correo electrónico es requerido",
 	"alertErrorForgotPasswordCode": "Hubo un error al enviar el código de verificación, por favor verifique su correo electrónico e intente nuevamente",

--- a/lib/src/screens/forgot_password/forgot_password.dart
+++ b/lib/src/screens/forgot_password/forgot_password.dart
@@ -88,10 +88,12 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
             textColor: Colors.white,
             fontSize: 16.0);
       } else {
-        String lastNumbers = (response.data?["initiateForgotPasswordRequest"]
+        /*String lastNumbers = (response.data?["initiateForgotPasswordRequest"]
             ["deliveryMedium"] as String);
         _phoneNumEnding =
-            (lastNumbers).substring(lastNumbers.length - 4, lastNumbers.length);
+            (lastNumbers).substring(lastNumbers.length - 4, lastNumbers.length);*/ //Code to show las 4 digits
+        _phoneNumEnding = (response.data?["initiateForgotPasswordRequest"]
+            ["deliveryMedium"] as String);
       }
     } catch (e) {
       _state.error = e.toString();

--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -168,7 +168,8 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     if (sourceCurrency == "DOP") {
       sourceAmount = double.parse(targetAmount) * alcanciaUSDCExchange;
     } else if (sourceCurrency == "USD") {
-      sourceAmount = double.parse(targetAmount) / alcanciaUSDtoUSDCRate;
+      sourceAmount = double.parse(targetAmount) +
+          double.parse(targetAmount) * (1 - alcanciaUSDtoUSDCRate);
     } else {
       sourceAmount = double.parse(targetAmount) *
           (targetCurrency == "USDC" ? suarmiUSDCExchage : suarmiCeloExchange);
@@ -326,6 +327,11 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                       setState(() {
                                         sourceCurrency = newValue;
                                         getCurrencyRate();
+                                        sourceAmountController.text =
+                                            calculateSourceAmount(
+                                                targetAmountController.text,
+                                                targetCurrency,
+                                                sourceCurrency);
                                         // when this components intis, we will exchange rate from suarmi and cryptopay
                                       });
                                     },

--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -77,7 +77,9 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
 
   // alcancia exchange
   var alcanciaUSDCExchange = 1.0;
+  var alcanciaUSDtoUSDCRate = 0.0;
 
+  late MapEntry<String, CountryConfig> remoteConfigCountry;
   // state
   bool _isLoading = false;
   bool _loadingCheckout = false;
@@ -152,7 +154,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     if (sourceCurrency == "DOP") {
       targetAmount = double.parse(sourceAmount) / alcanciaUSDCExchange;
     } else if (sourceCurrency == "USD") {
-      targetAmount = double.parse(sourceAmount) * 0.98;
+      targetAmount = double.parse(sourceAmount) * alcanciaUSDtoUSDCRate;
     } else {
       targetAmount = double.parse(sourceAmount) /
           (targetCurrency == "USDC" ? suarmiUSDCExchage : suarmiCeloExchange);
@@ -166,7 +168,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     if (sourceCurrency == "DOP") {
       sourceAmount = double.parse(targetAmount) * alcanciaUSDCExchange;
     } else if (sourceCurrency == "USD") {
-      sourceAmount = double.parse(targetAmount) / 0.98;
+      sourceAmount = double.parse(targetAmount) / alcanciaUSDtoUSDCRate;
     } else {
       sourceAmount = double.parse(targetAmount) *
           (targetCurrency == "USDC" ? suarmiUSDCExchage : suarmiCeloExchange);
@@ -191,21 +193,18 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     } else {
       sourceCurrency = sourceCurrencyCodes.first['name'];
     }
-    sourceCurrencyCodes = remoteConfigData.countryConfig.entries
-        .firstWhere(
-          (e) => e.key == user!.country && e.value.enabled == true,
-          orElse: () => MapEntry(
-              '',
-              CountryConfig(
-                  icon: '',
-                  enabled: false,
-                  currencies: {},
-                  cryptoCurrencies: {},
-                  banksWithdraw: null)),
-        )
-        .value
-        .currencies
-        .entries
+    remoteConfigCountry = remoteConfigData.countryConfig.entries.firstWhere(
+      (e) => e.key == user!.country && e.value.enabled == true,
+      orElse: () => MapEntry(
+          '',
+          CountryConfig(
+              icon: '',
+              enabled: false,
+              currencies: {},
+              cryptoCurrencies: {},
+              banksWithdraw: null)),
+    );
+    sourceCurrencyCodes = remoteConfigCountry.value.currencies.entries
         .where((element) => element.value.enabled == true)
         .map((e) => {"name": e.key, "icon": getIconByCurrencyFlag(e.key)})
         .toList();
@@ -326,6 +325,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                     onChanged: (newValue) {
                                       setState(() {
                                         sourceCurrency = newValue;
+                                        getCurrencyRate();
                                         // when this components intis, we will exchange rate from suarmi and cryptopay
                                       });
                                     },
@@ -387,6 +387,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                       : targetDOPCurrencies,
                                   onChanged: (newTargetCurrency) {
                                     setState(() {
+                                      getCurrencyRate();
                                       targetCurrency = newTargetCurrency;
                                     });
                                   },
@@ -427,8 +428,11 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                             Padding(
                               padding: const EdgeInsets.only(top: 16.0),
                               child: Text(
-                                generateCurrency(sourceCurrency,
-                                    suarmiUSDCExchage, alcanciaUSDCExchange),
+                                generateCurrency(
+                                    sourceCurrency,
+                                    suarmiUSDCExchage,
+                                    alcanciaUSDCExchange,
+                                    alcanciaUSDtoUSDCRate),
                                 style: TextStyle(
                                   fontSize: 13,
                                   fontWeight: FontWeight.normal,
@@ -586,7 +590,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                                 ? (double.parse(
                                                         sourceAmountController
                                                             .text) *
-                                                    0.98) //TODO: CHANGE TO REMOTE CONFIG VALUE
+                                                    alcanciaUSDtoUSDCRate) //TODO: CHANGE TO REMOTE CONFIG VALUE
                                                 : (double.parse(
                                                         sourceAmountController
                                                             .text) /
@@ -709,6 +713,22 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     );
   }
 
+  void getCurrencyRate() {
+    alcanciaUSDtoUSDCRate = remoteConfigCountry.value.cryptoCurrencies.entries
+        .firstWhere((e) => e.value.enabled == true && e.key == targetCurrency,
+            orElse: () => MapEntry(
+                '',
+                CryptoCurrency(
+                  depositRate: 0.0,
+                  enabled: true,
+                  icon: "null",
+                  maxAmount: 0,
+                  minAmount: 0,
+                )))
+        .value
+        .depositRate;
+  }
+
   String validateAmount(
       String sourceAmount, String sourceCurrency, AppLocalizations appLoc) {
     if (sourceCurrency == 'MXN') {
@@ -743,11 +763,11 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
 }
 
 String generateCurrency(String sourceCurrency, double suarmiUSDCExchage,
-    double alcanciaUSDCExchange) {
+    double alcanciaUSDCExchange, double alcanciaUSDtoUSDCRate) {
   if (sourceCurrency == "MXN") {
     return "*1 USDC = ${suarmiUSDCExchage.formatQuantity(2)} $sourceCurrency";
   } else if (sourceCurrency == "USD") {
-    return "*1 USD = ${(0.98).formatQuantity(2)} USDC";
+    return "*1 USD = ${alcanciaUSDtoUSDCRate.formatQuantity(2)} USDC";
   } else {
     return "*1 USDC = ${alcanciaUSDCExchange.formatQuantity(2)} $sourceCurrency";
   }

--- a/lib/src/screens/withdraw/withdraw_screen.dart
+++ b/lib/src/screens/withdraw/withdraw_screen.dart
@@ -174,7 +174,7 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
         )
         .value;
 
-    sourceCurrencies = sourceCurrenciesObjt.cryptoCurrencies.entries
+    sourceCurrencies = sourceCurrenciesObjt.currencies.entries
         .where((element) => element.value.enabled == true)
         .map((e) => {"name": e.key, "icon": e.value.icon})
         .toList();
@@ -472,7 +472,7 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
         ),
         LabeledTextFormField(
           controller: _targetTextController,
-          labelText: appLoc.labelAmountMXN,
+          labelText: "${appLoc.labelAmount} $sourceMXNCurrency",
           inputType: TextInputType.number,
           inputFormatters: [FilteringTextInputFormatter.digitsOnly],
           enabled: false,
@@ -586,7 +586,7 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
         ),
         LabeledTextFormField(
           controller: _targetTextController,
-          labelText: appLoc.labelAmountDOP,
+          labelText: "${appLoc.labelAmount} $sourceDOPCurrency",
           inputType: TextInputType.number,
           inputFormatters: [FilteringTextInputFormatter.digitsOnly],
           enabled: false,

--- a/lib/src/shared/models/remote_config_data.dart
+++ b/lib/src/shared/models/remote_config_data.dart
@@ -62,13 +62,13 @@ class CryptoCurrency {
   final String icon;
   final int minAmount;
   final int maxAmount;
-
-  CryptoCurrency({
-    required this.enabled,
-    required this.icon,
-    required this.minAmount,
-    required this.maxAmount,
-  });
+  final double depositRate;
+  CryptoCurrency(
+      {required this.enabled,
+      required this.icon,
+      required this.minAmount,
+      required this.maxAmount,
+      required this.depositRate});
 
   factory CryptoCurrency.fromJson(Map<String, dynamic> json) {
     return CryptoCurrency(
@@ -76,6 +76,7 @@ class CryptoCurrency {
       icon: json['icon'],
       minAmount: json['minAmount'],
       maxAmount: json['maxAmount'],
+      depositRate: json['depositRate'] as double,
     );
   }
 }


### PR DESCRIPTION
## Summary
Remote config. deposit exchange rete and withdraw exchange rate parametrizable.

## Requirements
A new field is created within crypto_currency called depositRate, which is used to vary the exchange rate within the deposit.
The exchangeRate variable is reused within the currency properties to manage the USD exchange rate on withdrawal.

## Type of change
- [X] feature
- [ ] hotfix
- [ ] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
Make a deposit and a withdraw. checkout transaction history.

## How has this been tested?

## Screenshots
![image](https://github.com/Alcancia-io/Alcancia-FrontEnd/assets/8390375/b0d26f25-fabc-42f9-918a-796a7c74a191)


## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?