### PR TITLE
OINK-1394 | Update Forgot Password Messaging

### DIFF
--- a/lib/src/screens/forgot_password/forgot_password.dart
+++ b/lib/src/screens/forgot_password/forgot_password.dart
@@ -41,6 +41,7 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
 
   String? _email;
   String _phoneNumEnding = "";
+  String _deliveryMedium = "";
   String _newPassword = '';
   String _verificationCode = '';
   bool _isButtonEnabled = false;
@@ -93,6 +94,8 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
         _phoneNumEnding =
             (lastNumbers).substring(lastNumbers.length - 4, lastNumbers.length);*/ //Code to show las 4 digits
         _phoneNumEnding = (response.data?["initiateForgotPasswordRequest"]
+            ["destination"] as String);
+        _deliveryMedium = (response.data?["initiateForgotPasswordRequest"]
             ["deliveryMedium"] as String);
       }
     } catch (e) {

--- a/lib/src/shared/graphql/queries/forgot_password_query.dart
+++ b/lib/src/shared/graphql/queries/forgot_password_query.dart
@@ -1,7 +1,8 @@
 const forgotPasswordQuery = """
   mutation(\$input: ForgotPasswordInput!) {
     initiateForgotPasswordRequest(input: \$input){
-      deliveryMedium
+      deliveryMedium,
+      destination
     }
   }
 """;


### PR DESCRIPTION
## Summary
Fixes #281 
Forgot password message ain't a cool thing. Obfuscated destinations enhance this message to be cool.

## Requirements
Currently when initiating a forgot Password request the messaging states just the MEDIUM the recovery code was sent with but not the destination. The backend team added an obfuscated DESTINATION field on the mutation so that we can render the email/sms destination on the UI
Examples of Obfuscated Destinations: 8640 or sil**@gmail.com

## Type of change
- [ ] feature
- [ ] hotfix
- [ ] fix
- [ ] refactor
- [X] chore
- [ ] docs

## How to test?
Go to forgot password screen, you should be able to see a masked phone number.

## How has this been tested?


## Screenshots


## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?