### PR TITLE
Hotfix: MXN Users Unable to WIthdraw and Showing incorrect Exchange in Deposit

### DIFF
--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -77,7 +77,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
 
   // alcancia exchange
   var alcanciaUSDCExchange = 1.0;
-  var alcanciaUSDtoUSDCRate = 0.0;
+  var alcanciaUSDtoUSDCRate = 1.0;
 
   late MapEntry<String, CountryConfig> remoteConfigCountry;
   // state
@@ -185,15 +185,6 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     getUsdcAPY();
     final user = ref.read(userProvider);
     final remoteConfigData = ref.read(remoteConfigDataStateProvider);
-    if (user?.country == "MX" && false) {
-      // TEMPORARY DISABLE MXN
-      sourceCurrency = "MXN";
-    } else if (user?.country == "DO" && false) {
-      // TEMPORARY DISABLE MXN
-      sourceCurrency = "DOP";
-    } else {
-      sourceCurrency = sourceCurrencyCodes.first['name'];
-    }
     remoteConfigCountry = remoteConfigData.countryConfig.entries.firstWhere(
       (e) => e.key == user!.country && e.value.enabled == true,
       orElse: () => MapEntry(
@@ -205,16 +196,28 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
               cryptoCurrencies: {},
               banksWithdraw: null)),
     );
-    sourceCurrencyCodes = remoteConfigCountry.value.currencies.entries
-        .where((element) => element.value.enabled == true)
-        .map((e) => {"name": e.key, "icon": getIconByCurrencyFlag(e.key)})
-        .toList();
+
+    if (user?.country == "MX" && false) {
+      // TEMPORARY DISABLE MXN
+      sourceCurrency = "MXN";
+    } else if (user?.country == "DO" && false) {
+      // TEMPORARY DISABLE MXN
+      sourceCurrency = "DOP";
+    } else {
+      sourceCurrencyCodes = remoteConfigCountry.value.currencies.entries
+          .where((element) => element.value.enabled == true)
+          .map((e) => {"name": e.key, "icon": getIconByCurrencyFlag(e.key)})
+          .toList();
+      sourceCurrency = sourceCurrencyCodes.first['name'] ?? 'USD';
+    }
+
     if (sourceCurrencyCodes.length > 1) {
       final sourceCurrencyIndex = sourceCurrencyCodes
           .indexWhere((element) => element['name'] == sourceCurrency);
       final code = sourceCurrencyCodes.removeAt(sourceCurrencyIndex);
       sourceCurrencyCodes.insert(0, code);
     }
+    getCurrencyRate();
   }
 
   @override

--- a/lib/src/screens/withdraw/withdraw_screen.dart
+++ b/lib/src/screens/withdraw/withdraw_screen.dart
@@ -144,6 +144,7 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
 
     if (user?.country == "MX") {
       country = "México";
+      countryCode = user!.country;
     } else if (user?.country == "DO") {
       country = "República Dominicana";
       countryCode = user!.country;


### PR DESCRIPTION
Happens to MX Users only

![image](https://github.com/Alcancia-io/Alcancia-FrontEnd/assets/42903129/5706d81e-efa2-4054-b1d3-17a14e72380a)
![image](https://github.com/Alcancia-io/Alcancia-FrontEnd/assets/42903129/7901541b-def2-4b3b-8b83-d802d28d17bd)

![image](https://github.com/Alcancia-io/Alcancia-FrontEnd/assets/42903129/ca36928c-1d3b-47b7-8e27-e516d9d3e5bd)


Fix:

-Set Default USD Exchange to 1.0
-Moved the Get RemoteConfig Currencies and Exchange BEFORE the Source Currency List is retrieved
- Adds Country Code MX Scenario for MXN users