### PR TITLE
Fixes issues caused by disabling MX in remote config

### DIFF
--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -193,13 +193,14 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
         .where((element) => element.value.enabled == true)
         .map((e) => {"name": e.key, "icon": e.value.icon})
         .toList();
+
+    sourceCurrency = sourceCurrencyCodes.first['name'];
     if (sourceCurrencyCodes.length > 1) {
       final sourceCurrencyIndex = sourceCurrencyCodes
           .indexWhere((element) => element['name'] == sourceCurrency);
       final code = sourceCurrencyCodes.removeAt(sourceCurrencyIndex);
       sourceCurrencyCodes.insert(0, code);
     }
-    sourceCurrency = sourceCurrencyCodes.first['name'];
     getCurrencyRate();
   }
 

--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -29,6 +29,11 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+String exchangeDisclaimer = "";
+
+final exchangeDisclaimerProvider =
+    StateProvider<String>((ref) => exchangeDisclaimer);
+
 class SwapScreen extends ConsumerStatefulWidget {
   const SwapScreen({Key? key}) : super(key: key);
 
@@ -116,6 +121,8 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
         suarmiCeloExchange = 1.0 / double.parse(mxnCeloRate);
         alcanciaUSDCExchange = dopExchangeRate;
       });
+      exchangeDisclaimer = generateCurrency(sourceCurrency, suarmiUSDCExchage,
+          alcanciaUSDCExchange, alcanciaUSDtoUSDCRate);
     } catch (err) {
       // print(err);
       _error = err.toString();
@@ -184,6 +191,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     getExchange();
     getCeloAPY();
     getUsdcAPY();
+
     final remoteConfigData = ref.read(remoteConfigDataStateProvider);
     remoteConfigCountry = remoteConfigData.countryConfig.entries.firstWhere(
       (e) => e.key == user!.country && e.value.enabled == true,
@@ -236,6 +244,8 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     Color cardColor = Theme.of(context).brightness == Brightness.dark
         ? alcanciaCardDark
         : alcanciaFieldLight;
+
+    String exchangeDisclaimerText = ref.watch(exchangeDisclaimerProvider);
 
     return GestureDetector(
       onTap: () {
@@ -313,6 +323,15 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                     onChanged: (newValue) {
                                       setState(() {
                                         sourceCurrency = newValue;
+                                        ref
+                                                .read(exchangeDisclaimerProvider
+                                                    .notifier)
+                                                .state =
+                                            generateCurrency(
+                                                sourceCurrency,
+                                                suarmiUSDCExchage,
+                                                alcanciaUSDCExchange,
+                                                alcanciaUSDtoUSDCRate);
                                         getCurrencyRate();
                                         sourceAmountController.text =
                                             calculateSourceAmount(
@@ -421,11 +440,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                             Padding(
                               padding: const EdgeInsets.only(top: 16.0),
                               child: Text(
-                                generateCurrency(
-                                    sourceCurrency,
-                                    suarmiUSDCExchage,
-                                    alcanciaUSDCExchange,
-                                    alcanciaUSDtoUSDCRate),
+                                exchangeDisclaimerText,
                                 style: TextStyle(
                                   fontSize: 13,
                                   fontWeight: FontWeight.normal,

--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -187,14 +187,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     final remoteConfigData = ref.read(remoteConfigDataStateProvider);
     remoteConfigCountry = remoteConfigData.countryConfig.entries.firstWhere(
       (e) => e.key == user!.country && e.value.enabled == true,
-      orElse: () => MapEntry(
-          '',
-          CountryConfig(
-              icon: '',
-              enabled: false,
-              currencies: {},
-              cryptoCurrencies: {},
-              banksWithdraw: null)),
+      orElse: () => remoteConfigData.countryConfig.entries.first,
     );
     sourceCurrencyCodes = remoteConfigCountry.value.currencies.entries
         .where((element) => element.value.enabled == true)

--- a/lib/src/screens/withdraw/withdraw_screen.dart
+++ b/lib/src/screens/withdraw/withdraw_screen.dart
@@ -103,8 +103,8 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
           .firstWhere((e) => e.key == "MX")
           .value
           .enabled;
-      var mxnExchangeRate = "";
-      var mxnCeloRate = "";
+      var mxnExchangeRate = "0.0";
+      var mxnCeloRate = "0.0";
       if (isMxEnabled) {
         mxnExchangeRate =
             await controller.getSuarmiExchange(sourceCurrency: "USDC");
@@ -142,36 +142,18 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
       _clabeTextController.text = user!.lastUsedBankAccount!;
     }
 
-    if (user?.country == "MX") {
-      country = "México";
-      countryCode = user!.country;
-    } else if (user?.country == "DO") {
-      country = "República Dominicana";
-      countryCode = user!.country;
-    } else {
-      country = countries.first['name'];
-    }
+    country = getCountryFromCode(user!.country);
+    countryCode = user.country;
 
     countries = remoteConfigDataSet.countryConfig.entries
         .where((element) => element.value.enabled == true)
         .map((e) => {"name": getCountryFromCode(e.key), "icon": e.value.icon})
         .toList();
-    final countryIndex =
-        countries.indexWhere((element) => element['name'] == country);
-    final code = countries.removeAt(countryIndex);
-    countries.insert(0, code);
 
     sourceCurrenciesObjt = remoteConfigDataSet.countryConfig.entries
         .firstWhere(
           (e) => e.key == countryCode && e.value.enabled == true,
-          orElse: () => MapEntry(
-              '',
-              CountryConfig(
-                  icon: '',
-                  enabled: false,
-                  currencies: {},
-                  cryptoCurrencies: {},
-                  banksWithdraw: null)),
+          orElse: () => remoteConfigDataSet.countryConfig.entries.first,
         )
         .value;
 


### PR DESCRIPTION
## Summary
Fixes #298 
When disabling MX in Remote Configs (or any country) Deposits and Withdraws get an error because of the default empty config values set if the user's country is not found on the config. Instead, if the user's country is not found, the first country is set as default.

Has to be Merged after: #295 

## Type of change
- [ ] feature
- [ ] hotfix
- [X] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
-Disable MX as a country in the remote configs and as Mexican user use any transaction screen
