### PR TITLE
Fixes: Empty Defaults and bad UI for Country Selector

### DIFF
--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -108,8 +108,8 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
           .value
           .enabled;
 
-      var mxnExchangeRate = "";
-      var mxnCeloRate = "";
+      var mxnExchangeRate = "1.0";
+      var mxnCeloRate = "1.0";
       if (isMxEnabled) {
         mxnExchangeRate = await swapController.getSuarmiExchange("USDC");
         mxnCeloRate = await swapController.getSuarmiExchange("cUSD");
@@ -642,14 +642,11 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                                         e.key ==
                                                             user!.country &&
                                                         e.value.enabled == true,
-                                                    orElse: () => MapEntry(
-                                                        '',
-                                                        CountryConfig(
-                                                            icon: '',
-                                                            enabled: false,
-                                                            currencies: {},
-                                                            banksWithdraw: null,
-                                                            cryptoCurrencies: {})),
+                                                    orElse: () =>
+                                                        remoteConfigData
+                                                            .countryConfig
+                                                            .entries
+                                                            .first,
                                                   )
                                                   .value;
                                           if (sourceCurrenciesObjt
@@ -724,15 +721,8 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
   void getCurrencyRate() {
     alcanciaUSDtoUSDCRate = remoteConfigCountry.value.cryptoCurrencies.entries
         .firstWhere((e) => e.value.enabled == true && e.key == targetCurrency,
-            orElse: () => MapEntry(
-                '',
-                CryptoCurrency(
-                  depositRate: 0.0,
-                  enabled: true,
-                  icon: "null",
-                  maxAmount: 0,
-                  minAmount: 0,
-                )))
+            orElse: () =>
+                remoteConfigCountry.value.cryptoCurrencies.entries.first)
         .value
         .depositRate;
   }

--- a/lib/src/screens/withdraw/withdraw_screen.dart
+++ b/lib/src/screens/withdraw/withdraw_screen.dart
@@ -142,13 +142,23 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
       _clabeTextController.text = user!.lastUsedBankAccount!;
     }
 
-    country = getCountryFromCode(user!.country);
-    countryCode = user.country;
-
     countries = remoteConfigDataSet.countryConfig.entries
         .where((element) => element.value.enabled == true)
         .map((e) => {"name": getCountryFromCode(e.key), "icon": e.value.icon})
         .toList();
+    //Put the User's Country as first on the Countries list
+    int currentUserCountryIndex = countries.indexWhere(
+        (element) => element['name'] == getCountryFromCode(user!.country));
+    if (currentUserCountryIndex != -1) {
+      countries.insert(0, countries.removeAt(currentUserCountryIndex));
+    }
+    country = getCountryFromCode(remoteConfigDataSet.countryConfig.entries
+        .firstWhere(
+          (e) => e.value.enabled == true && e.key == user!.country,
+          orElse: () => remoteConfigDataSet.countryConfig.entries.first,
+        )
+        .key);
+    countryCode = user!.country;
 
     sourceCurrenciesObjt = remoteConfigDataSet.countryConfig.entries
         .firstWhere(


### PR DESCRIPTION
## Summary
-Removed Empty default values from the swap screen the caused issues
-Added country sorting on withdraw screen if the current user's country is enabled


## Type of change
- [ ] feature
- [ ] hotfix
- [X] fix
- [ ] refactor
- [ ] chore
- [ ] docs
